### PR TITLE
fix(consumer): 修复在使用默认配置运行最简单的 demo 代码时，程序在启动消费后立产生的异常

### DIFF
--- a/funboost/consumers/persist_queue_consumer.py
+++ b/funboost/consumers/persist_queue_consumer.py
@@ -13,7 +13,7 @@ class PersistQueueConsumer(AbstractConsumer):
     """
 
     def _shedual_task(self):
-        pub = PersistQueuePublisher(publisher_params=PublisherParams(queue_name=self.queue_name))
+        pub = PersistQueuePublisher(publisher_params=PublisherParams(queue_name=self.queue_name,consuming_function=self.consuming_function))
         while True:
             item = pub.queue.get()
             # self.logger.debug(f'从本地持久化sqlite的 [{self._queue_name}] 队列中 取出的消息是：   {item}  ')


### PR DESCRIPTION
在 `funboost/consumers/persist_queue_consumer.py` 文件的 `_shedual_task` 方法中，初始化 `PersistQueuePublisher` 时，`PublisherParams` 缺少 `consuming_function` 参数。
这导致 `base_publisher.py` 初始化检查参数时，`consuming_function` 为 `None`，进而导致 `inspect` 模块报错。
`Code Location`:`funboost/consumers/persist_queue_consumer.py` around line 16.


更新版本后运行demo代码发现报错

```
import time
from funboost import boost, BrokerEnum, BoosterParams

# 1. 为你的函数加上 @boost 装饰器
@boost(BoosterParams(queue_name="hello_queue", qps=5))
def say_hello(name: str):
    print(f"Hello, {name}!")
    time.sleep(1)

if __name__ == "__main__":
    # 2. 发布任务并启动消费
    for i in range(50):
        say_hello.push(name=f"Funboost User {i}")
    
    say_hello.consume()

------
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "D:\Githubs\byseven-spiders\.venv\Lib\site-packages\funboost\consumers\base_consumer.py", line 336, in ___keep_circulating
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "D:\Githubs\byseven-spiders\.venv\Lib\site-packages\funboost\consumers\persist_queue_consumer.py", line 16, in _shedual_task
    pub = PersistQueuePublisher(publisher_params=PublisherParams(queue_name=self.queue_name))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Githubs\byseven-spiders\.venv\Lib\site-packages\funboost\publishers\base_publisher.py", line 104, in __init__
    ConsumingFuncInputParamsChecker.gen_final_func_input_params_info(publisher_params)
  File "D:\Githubs\byseven-spiders\.venv\Lib\site-packages\funboost\core\consuming_func_iniput_params_check.py", line 100, in gen_final_func_input_params_info
    consuming_func_input_params_list_info =  cls.gen_func_params_info_by_func(consumer_or_publisher_params.consuming_function)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Githubs\byseven-spiders\.venv\Lib\site-packages\funboost\core\consuming_func_iniput_params_check.py", line 51, in gen_func_params_info_by_func
    spec = inspect.getfullargspec(func)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\fansir\AppData\Roaming\uv\python\cpython-3.11.12-windows-x86_64-none\Lib\inspect.py", line 1375, in getfullargspec
    raise TypeError('unsupported callable') from ex
TypeError: unsupported callable
2025-12-17 16:45:41-(10.8.0.43,HomePC)-[p1476_t40124] - funboost.PersistQueueConsumer--hello_queue - "base_consumer.py:344" - ___keep_circulating - ERROR - no_task_id - _shedual_task   运行出错
 Traceback (most recent call last):
  File "C:\Users\fansir\AppData\Roaming\uv\python\cpython-3.11.12-windows-x86_64-none\Lib\inspect.py", line 1365, in getfullargspec
    sig = _signature_from_callable(func,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\fansir\AppData\Roaming\uv\python\cpython-3.11.12-windows-x86_64-none\Lib\inspect.py", line 2456, in _signature_from_callable
    raise TypeError('{!r} is not a callable object'.format(obj))
TypeError: None is not a callable object

The above exception was the direct cause of the following exception:



```
